### PR TITLE
write past end to improve speed

### DIFF
--- a/outdeps.d
+++ b/outdeps.d
@@ -66,6 +66,7 @@ R dependencyFileFormat(R)(ref R r, string[] deps) if (isOutputRange!(R, char))
     return r;
 }
 
+
 unittest
 {
     string[] deps = ["asdfasdf.d", "kjjksdkfj.d", "asdkjfksdfj.d",
@@ -74,7 +75,7 @@ unittest
                 ];
 
     char[1000] buf;
-    Textbuf!char textbuf;
+    auto textbuf = Textbuf!char(buf);
 
     textbuf.dependencyFileFormat(deps);
     auto r = textbuf[0 .. textbuf.length];
@@ -101,6 +102,7 @@ asdkjfksdfj1.d:
 ");
     textbuf.free();
 }
+
 
 /*************************************
  * Write dependencies to filename.


### PR DESCRIPTION
It turns out that writing to the buffer before increasing its size saves a save/restore of `c` on the stack, since `resize()` destroys registers.

Also fixes a memory corruption bug in outdeps.d this uncovered.
