### PR TITLE
.init() => .initialize()

### DIFF
--- a/lexer.d
+++ b/lexer.d
@@ -89,7 +89,7 @@ struct Lexer(R) if (isInputRange!R)
     R src;
 
     alias Unqual!(ElementEncodingType!R) E;
-    BitBucket!E bitbucket = void;
+    ranges.BitBucket!E bitbucket = void;
 
     //enum bool isContext = std.traits.hasMember!(R, "expanded");
     enum bool isContext = __traits(compiles, src.expanded);
@@ -517,7 +517,7 @@ struct Lexer(R) if (isInputRange!R)
                             src.expanded.off();
                         }
                     }
-                    idbuf.init();
+                    idbuf.initialize();
                     src = src.inIdentifier(idbuf);
                 Lident:
                     if (noMacroExpand)
@@ -695,7 +695,7 @@ struct Lexer(R) if (isInputRange!R)
                             src.expanded.off();
                         }
                     }
-                    idbuf.init();
+                    idbuf.initialize();
                     src = src.inIdentifier(idbuf);
                     if (!src.empty)
                     {

--- a/macros.d
+++ b/macros.d
@@ -162,7 +162,7 @@ ustring macroReplacementList(R)(ref R text, bool objectLike, ustring[] parameter
                      */
                     text = text.skipWhitespace();
                     StaticArrayBuffer!(uchar, 1024) id = void;
-                    id.init();
+                    id.initialize();
                     text = text.inIdentifier(id);
                     auto argi = countUntil(parameters, id[]);
                     if (argi == -1)
@@ -183,7 +183,7 @@ ustring macroReplacementList(R)(ref R text, bool objectLike, ustring[] parameter
                     if (parameters.length)
                     {
                         StaticArrayBuffer!(uchar, 1024) id = void;
-                        id.init();
+                        id.initialize();
                         id.put(c);
                         text = text.inIdentifier(id);
                         auto argi = countUntil(parameters, id[]);
@@ -1525,42 +1525,42 @@ unittest
 {
     StaticArrayBuffer!(uchar, 1024) buf = void;
 
-    buf.init();
+    buf.initialize();
     auto s = cast(ustring)"";
     buf.writePreprocessedLine(s);
     assert(buf[] == "\n");
 
-    buf.init();
+    buf.initialize();
     s = cast(ustring)"\r\na b\x07";
     buf.writePreprocessedLine(s);
 //writefln("|%s| %s", buf[], buf[].length);
     assert(buf[] == "a b\x07\n");
 
-    buf.init();
+    buf.initialize();
     s = cast(ustring)("" ~ ESC.brk ~ "");
     buf.writePreprocessedLine(s);
 //writefln("|%s| %s", buf[], buf[].length);
     assert(buf[] == "\n");
 
-    buf.init();
+    buf.initialize();
     s = cast(ustring)("" ~ ESC.brk ~ ESC.brk ~ ESC.brk ~ "");
     buf.writePreprocessedLine(s);
 //writefln("|%s| %s", buf[], buf[].length);
     assert(buf[] == "\n");
 
-    buf.init();
+    buf.initialize();
     s = cast(ustring)("a" ~ ESC.brk ~ ESC.brk ~ ESC.brk ~ "");
     buf.writePreprocessedLine(s);
 //writefln("|%s| %s", buf[], buf[].length);
     assert(buf[] == "a\n");
 
-    buf.init();
+    buf.initialize();
     s = cast(ustring)("a" ~ ESC.brk ~ ESC.brk ~ "b" ~ ESC.brk ~ "+");
     buf.writePreprocessedLine(s);
 //writefln("|%s| %s", buf[], buf[].length);
     assert(buf[] == "a b+\n");
 
-    buf.init();
+    buf.initialize();
     s = cast(ustring)("+" ~ ESC.brk ~ "+" ~ ESC.brk ~ "(");
     buf.writePreprocessedLine(s);
 //writefln("|%s| %s", buf[], buf[].length);

--- a/ranges.d
+++ b/ranges.d
@@ -34,15 +34,21 @@ struct EmptyInputRange(E)
 
 struct StaticArrayBuffer(E, size_t N)
 {
-    E[N] arr = void;
     size_t i;
+    E[N] arr = void;
 
-    void init() { i = 0; }
+    void initialize() { i = 0; }
 
     void put(E e)
     {
         arr[i] = e;
         ++i;
+    }
+
+    void put(E[] e)
+    {
+        arr[i .. i + e.length] = e[];
+        i += e.length;
     }
 
     E[] opSlice()
@@ -58,7 +64,7 @@ struct StaticArrayBuffer(E, size_t N)
 unittest
 {
     StaticArrayBuffer!(ubyte, 2) buf = void;
-    buf.init();
+    buf.initialize();
     buf.put('a');
     buf.put('b');
 //writefln("'%s'", buf.get());

--- a/skip.d
+++ b/skip.d
@@ -145,7 +145,7 @@ unittest
     assert(!r.empty && r.front == 'x');
 
     StaticArrayBuffer!(char,100) a = void;
-    a.init();
+    a.initialize();
 
     r = "asdf\\'a'b".skipCharacterLiteral(a);
     assert(!r.empty && r.front == 'b');
@@ -197,7 +197,7 @@ unittest
     assert(!r.empty && r.front == 'x');
 
     StaticArrayBuffer!(char,100) a = void;
-    a.init();
+    a.initialize();
 
     r = "asdf\\\"a\"b".skipStringLiteral(a);
     assert(!r.empty && r.front == 'b');
@@ -301,13 +301,13 @@ R skipRawStringLiteral(alias error = err_fatal, R, S)(R r, ref S s)
 unittest
 {
     StaticArrayBuffer!(char,100) a = void;
-    a.init();
+    a.initialize();
 
     auto r = "a(bcd\")b\")a\"e".skipRawStringLiteral(a);
     assert(!r.empty && r.front == 'e');
     assert(a[] == "a(bcd\")b\")a\"");
 
-    a.init();
+    a.initialize();
     r = "(([^\\s]*)\\s+(.*))\"e".skipRawStringLiteral(a);
     assert(!r.empty && r.front == 'e');
     assert(a[] == "(([^\\s]*)\\s+(.*))\"");
@@ -411,13 +411,13 @@ unittest
 {
   {
     StaticArrayBuffer!(char, 1024) id = void;
-    id.init();
+    id.initialize();
     auto r = "abZ123_ 3".inIdentifier(id);
     assert(!r.empty && r.front == ' ' && id[] == "abZ123_");
   }
   {
     StaticArrayBuffer!(ubyte, 1024) id = void;
-    id.init();
+    id.initialize();
     auto r = (cast(immutable(ubyte)[])"abZ123_ 3").inIdentifier(id);
     assert(!r.empty && r.front == ' ' && id[] == "abZ123_");
   }
@@ -526,3 +526,4 @@ unittest
     r2 = s2.skipBlankLine();
     assert(r2.empty);
 }
+

--- a/stringlit.d
+++ b/stringlit.d
@@ -221,31 +221,31 @@ unittest
 {
     StaticArrayBuffer!(char, 100) buf = void;
 
-    buf.init();
+    buf.initialize();
     auto r = `abc"`.lexStringLiteral(buf, '"', STR.s);
     assert(r.empty && buf[] == "abc");
 
-    buf.init();
+    buf.initialize();
     r = `\\\"\'\?\a\b\f\n\r\t\v"`.lexStringLiteral(buf, '"', STR.s);
     assert(r.empty && buf[] == "\\\"\'\?\a\b\f\n\r\t\v");
 
-    buf.init();
+    buf.initialize();
     r = `\0x\1773"`.lexStringLiteral(buf, '"', STR.s);
     assert(r.empty && buf[] == "\0x\1773");
 
-    buf.init();
+    buf.initialize();
     r = `\xa\xAFc"`.lexStringLiteral(buf, '"', STR.s);
 //writefln("|%s|", buf[]);
     assert(r.empty && buf[] == "\x0a\xafc");
 
-    buf.init();
+    buf.initialize();
     r = `\uabcdc"`.lexStringLiteral(buf, '"', STR.u);
     assert(r.empty && buf.length == 4 && buf[][0] == 0xCD &&
                                          buf[][1] == 0xAB &&
                                          buf[][2] == 'c'  &&
                                          buf[][3] == 0x00);
 
-    buf.init();
+    buf.initialize();
     r = `\U000DEF01c"`.lexStringLiteral(buf, '"', STR.U);
 //writef("%d:", buf.length);
 //foreach (c; 0..buf.length) writef(" %02x", buf[][c]);
@@ -269,7 +269,7 @@ R lexCharacterLiteral(R)(R r, ref ppint_t i, STR str)
     alias Unqual!(ElementEncodingType!R) E;
 
     StaticArrayBuffer!(E, 100) buf;
-    buf.init();
+    buf.initialize();
 
     r = r.lexStringLiteral(buf, '\'', str);
 


### PR DESCRIPTION
Shouldn't have a member named .init

added put() overload - will use later

reordered fields for 0 offset instead of large offset
