### PR TITLE
checked for raw string literal in wrong place

### DIFF
--- a/macros.d
+++ b/macros.d
@@ -889,16 +889,8 @@ void macroExpand(Context, R)(const(uchar)[] text, ref R outbuf)
                  * examining their insides
                  */
                 r.popFront();
-                if (outbuf.length && outbuf.last() == 'R')
-                {
-                    outbuf.put(c);
-                    r = r.skipRawStringLiteral(outbuf);
-                }
-                else
-                {
-                    outbuf.put(c);
-                    r = r.skipStringLiteral(outbuf);
-                }
+                outbuf.put(c);
+                r = r.skipStringLiteral(outbuf);
                 continue;
 
             case '\'':


### PR DESCRIPTION
test case:

```
#define LOG(severity, ...) severity __VA_ARGS__
#define EVERY(severity, ...) LOG(severity, ##__VA_ARGS__)
EVERY(ER, "Data", line);
```
